### PR TITLE
remove use of equal operator where void is returned

### DIFF
--- a/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
+++ b/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
@@ -101,7 +101,9 @@ class EncryptedStorage private constructor() {
          * */
         fun registerOnSharedPreferenceChangeListener(
             listener: SharedPreferences.OnSharedPreferenceChangeListener
-        ) = prefs.registerOnSharedPreferenceChangeListener(listener)
+        ) {
+            prefs.registerOnSharedPreferenceChangeListener(listener)
+        }
 
         /**
          * Unregisters an onChangeListener for SharedPreferences.
@@ -110,7 +112,9 @@ class EncryptedStorage private constructor() {
          * */
         fun unregisterOnSharedPreferenceChangeListener(
             listener: SharedPreferences.OnSharedPreferenceChangeListener
-        ) = prefs.unregisterOnSharedPreferenceChangeListener(listener)
+        ) {
+            prefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
 
         ///////////////////////
         // Read Shared Prefs //


### PR DESCRIPTION
This PR removes the use of the `=` operator where `void` is returned. Java users do not have access to `kotlin.Unit`, which causes issues.