### PR TITLE
Modify File class name as to not clash with java.io.File

### DIFF
--- a/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
+++ b/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedFile
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 
@@ -336,7 +337,7 @@ class EncryptedStorage private constructor() {
      * See [EFile.Companion.createEncrypted] for instantiation methods.
      * */
     class EFile private constructor(
-        val file: java.io.File,
+        val file: File,
         context: Context,
         val keysetAlias: String?,
         val keysetPrefName: String?
@@ -347,19 +348,19 @@ class EncryptedStorage private constructor() {
             /**
              * Required fields only
              * */
-            fun createEncrypted(file: java.io.File, context: Context): EFile =
+            fun createEncrypted(file: File, context: Context): EFile =
                 EFile(file, context, null, null)
 
             /**
              * Required fields + custom keysetAlias
              * */
-            fun createEncrypted(file: java.io.File, context: Context, keysetAlias: String): EFile =
+            fun createEncrypted(file: File, context: Context, keysetAlias: String): EFile =
                 EFile(file, context, keysetAlias, null)
 
             /**
              * Required fields + custom keysetPrefName
              * */
-            fun createEncrypted(file: java.io.File, keysetPrefName: String, context: Context): EFile =
+            fun createEncrypted(file: File, keysetPrefName: String, context: Context): EFile =
                 EFile(file, context, null, keysetPrefName)
 
             /**
@@ -377,7 +378,7 @@ class EncryptedStorage private constructor() {
              * @throws [java.io.IOException] when the file already exists or is not available for writing
              * */
             fun createEncrypted(
-                file: java.io.File,
+                file: File,
                 context: Context,
                 keysetAlias: String,
                 keysetPrefName: String
@@ -388,7 +389,7 @@ class EncryptedStorage private constructor() {
         private val encryptedFile = buildEncryptedFile(file, context, keysetAlias, keysetPrefName)
 
         private fun buildEncryptedFile(
-            file: java.io.File,
+            file: File,
             context: Context,
             keysetAlias: String?,
             keysetPrefName: String?

--- a/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
+++ b/encrypted-storage/src/main/java/io/matthewnelson/encrypted_storage/EncryptedStorage.kt
@@ -333,9 +333,9 @@ class EncryptedStorage private constructor() {
     /**
      * Helper class for creating encrypted Files.
      *
-     * See [File.Companion.createEncrypted] for instantiation methods.
+     * See [EFile.Companion.createEncrypted] for instantiation methods.
      * */
-    class File private constructor(
+    class EFile private constructor(
         val file: java.io.File,
         context: Context,
         val keysetAlias: String?,
@@ -347,20 +347,20 @@ class EncryptedStorage private constructor() {
             /**
              * Required fields only
              * */
-            fun createEncrypted(file: java.io.File, context: Context): File =
-                File(file, context, null, null)
+            fun createEncrypted(file: java.io.File, context: Context): EFile =
+                EFile(file, context, null, null)
 
             /**
              * Required fields + custom keysetAlias
              * */
-            fun createEncrypted(file: java.io.File, context: Context, keysetAlias: String): File =
-                File(file, context, keysetAlias, null)
+            fun createEncrypted(file: java.io.File, context: Context, keysetAlias: String): EFile =
+                EFile(file, context, keysetAlias, null)
 
             /**
              * Required fields + custom keysetPrefName
              * */
-            fun createEncrypted(file: java.io.File, keysetPrefName: String, context: Context): File =
-                File(file, context, null, keysetPrefName)
+            fun createEncrypted(file: java.io.File, keysetPrefName: String, context: Context): EFile =
+                EFile(file, context, null, keysetPrefName)
 
             /**
              * Required: [file], [context]
@@ -371,7 +371,7 @@ class EncryptedStorage private constructor() {
              * @param [keysetAlias] String - **OPTIONAL** FIELD
              * @param [keysetPrefName] String - **OPTIONAL** FIELD
              *
-             * @return [EncryptedStorage.File]
+             * @return [EncryptedStorage.EFile]
              *
              * @throws [java.security.GeneralSecurityException]  when a bad master key or keyset has been used
              * @throws [java.io.IOException] when the file already exists or is not available for writing
@@ -381,8 +381,8 @@ class EncryptedStorage private constructor() {
                 context: Context,
                 keysetAlias: String,
                 keysetPrefName: String
-            ): File =
-                File(file, context, keysetAlias, keysetPrefName)
+            ): EFile =
+                EFile(file, context, keysetAlias, keysetPrefName)
         }
 
         private val encryptedFile = buildEncryptedFile(file, context, keysetAlias, keysetPrefName)


### PR DESCRIPTION
This PR modifies the `EncryptedStorage.File` class name to `EFile` as to not clash with `java.io.File` and make things more distinct.