### PR TITLE
bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.4.10"
     repositories {
         google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath "com.android.tools.build:gradle:4.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.12.0'

--- a/encrypted-storage/build.gradle
+++ b/encrypted-storage/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.3"
 
     testOptions.unitTests.includeAndroidResources = true
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 
@@ -61,11 +61,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation project(':fake-keystore')
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testImplementation "org.robolectric:robolectric:4.3.1"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "org.robolectric:robolectric:4.4"
+    testImplementation 'androidx.test:core:1.3.0'
 
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 
 }

--- a/fake-keystore/build.gradle
+++ b/fake-keystore/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/maven-publish.gradle')
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+# https://gradle.org/release-checksums/
+distributionSha256Sum=11657af6356b7587bfb37287b5992e94a9686d5c8a0a1b60b87b9928a2decde5
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip


### PR DESCRIPTION
This PR updates the following dependencies:
 - Kotlin from `1.3.72` -> `1.4.10`
 - Android Gradle Plugin from `4.0.1` -> `4.1.0`
 - Robolectric from `4.3.1` -> `4.4`
 - AndroidX Test Core from `1.2.0` -> `1.3.0`
 - Espresso Core from `3.2.0` -> `3.3.0`
 - Junit Ext from `1.1.1` -> `1.1.2`
 - Gradle from `6.1.1` -> `6.6.1`

And ups the CompileSdk version from `29` -> `30`